### PR TITLE
Renovate: only update digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["digest", "minor", "patch"],
+      "matchUpdateTypes": ["digest"],
       "groupName": "{{depName}} Docker updates"
     }
   ]


### PR DESCRIPTION
Since the Fedora tags do not follow semantic versioning, instruct Renovate Bot to only update digests.  Major version updates to Fedora 42 and beyond will be done manually.  That's the UX I desire.

Without this change, Renvoate will keep opening PRs to bump the image to the F42 image which is already available in a very early development stage.