### PR TITLE
add bootc-lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,7 @@ RUN dnf install -y \
 	vgrep
 
 RUN systemctl set-default graphical.target
+
+RUN rm -rf /var/run && ln -s /run /var/
+RUN ls -la /var/run
+RUN bootc container lint


### PR DESCRIPTION
Also symlink /var/run -> /run to address
https://gitlab.com/fedora/bootc/base-images/-/issues/28 which will eventually be fixed in the base image(s).